### PR TITLE
Fix new activity builds and postMessage communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 # working notes
 CHANGES.md
 Deployment.md
+AUTH_ISSUES.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 
 # working notes
 CHANGES.md
+Deployment.md

--- a/DelayDiscounting/public/index.html
+++ b/DelayDiscounting/public/index.html
@@ -2,20 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <title>React App</title>
+    <title>DelayDiscounting</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class="main">
       <div id="root"></div>
     </div>

--- a/DelayDiscounting/src/components/Board.tsx
+++ b/DelayDiscounting/src/components/Board.tsx
@@ -335,7 +335,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [delays, delayedAmount, trialsPerDelay, totalTrials]
   );
@@ -355,7 +355,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -365,7 +365,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>

--- a/LetterLogic/src/components/Board.tsx
+++ b/LetterLogic/src/components/Board.tsx
@@ -359,7 +359,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [difficulty, diffConfig]
   );
@@ -440,7 +440,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -450,7 +450,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>

--- a/LexicalDecision/src/components/Board.tsx
+++ b/LexicalDecision/src/components/Board.tsx
@@ -433,7 +433,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [difficulty, fixationMs, timeLimitMs]
   );
@@ -452,7 +452,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -462,7 +462,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>

--- a/MemoryMatch/.gitignore
+++ b/MemoryMatch/.gitignore
@@ -11,6 +11,8 @@
 # production
 /build
 /dist
+dist.html
+dist.html.b64
 
 # misc
 .DS_Store

--- a/MemoryMatch/public/index.html
+++ b/MemoryMatch/public/index.html
@@ -2,17 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <title>React App</title>
+    <title>MemoryMatch</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class="main">
       <div id="root"></div>
     </div>

--- a/MemoryMatch/src/components/Board.tsx
+++ b/MemoryMatch/src/components/Board.tsx
@@ -370,7 +370,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [timeLimitMs, difficulty]
   );
@@ -406,7 +406,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -416,7 +416,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>

--- a/MentalRotation/public/index.html
+++ b/MentalRotation/public/index.html
@@ -2,14 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <title>React App</title>
+    <title>MentalRotation</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class="main">
       <div id="root"></div>
     </div>

--- a/MentalRotation/src/components/Board.tsx
+++ b/MentalRotation/src/components/Board.tsx
@@ -436,7 +436,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [difficulty, timeLimitMs]
   );
@@ -463,7 +463,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -473,7 +473,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>

--- a/Nonogram/public/index.html
+++ b/Nonogram/public/index.html
@@ -2,17 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <title>React App</title>
+    <title>Nonogram</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class="main">
       <div id="root"></div>
     </div>

--- a/Nonogram/src/components/Board.tsx
+++ b/Nonogram/src/components/Board.tsx
@@ -616,7 +616,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [maxPuzzles, timeLimitMs, difficulty]
   );
@@ -661,7 +661,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -671,7 +671,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>

--- a/ScratchImage/.gitignore
+++ b/ScratchImage/.gitignore
@@ -24,3 +24,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+NOTES.md

--- a/SlidingPuzzle/src/components/Board.tsx
+++ b/SlidingPuzzle/src/components/Board.tsx
@@ -464,7 +464,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [difficulty, diffConfig, timeLimitMs]
   );
@@ -513,7 +513,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -523,7 +523,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>

--- a/TowerOfLondon/public/index.html
+++ b/TowerOfLondon/public/index.html
@@ -2,20 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <title>React App</title>
+    <title>TowerOfLondon</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class="main">
       <div id="root"></div>
     </div>

--- a/TowerOfLondon/src/components/Board.tsx
+++ b/TowerOfLondon/src/components/Board.tsx
@@ -480,7 +480,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [maxProblems, timeLimitMs]
   );
@@ -505,7 +505,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -515,7 +515,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>

--- a/WCST/src/components/Board.tsx
+++ b/WCST/src/components/Board.tsx
@@ -501,7 +501,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [deckSize, timeLimitMs]
   );
@@ -529,7 +529,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -539,7 +539,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>

--- a/WaterSort/public/index.html
+++ b/WaterSort/public/index.html
@@ -2,20 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
-    <title>React App</title>
+    <title>WaterSort</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div class="main">
       <div id="root"></div>
     </div>

--- a/WaterSort/src/components/Board.tsx
+++ b/WaterSort/src/components/Board.tsx
@@ -579,7 +579,7 @@ const Board: React.FC<Props> = ({ data }) => {
       };
 
       setPhase("done");
-      parent.postMessage(payload, "*");
+      parent.postMessage(JSON.stringify(payload), "*");
     },
     [maxPuzzles, timeLimitMs, difficulty]
   );
@@ -611,7 +611,7 @@ const Board: React.FC<Props> = ({ data }) => {
       <div className="heading">
         <span
           className="back-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faArrowLeft} />
         </span>
@@ -621,7 +621,7 @@ const Board: React.FC<Props> = ({ data }) => {
         </span>
         <span
           className="home-link"
-          onClick={() => parent.postMessage({ abort: true }, "*")}
+          onClick={() => parent.postMessage(JSON.stringify({ timestamp: new Date().getTime(), clickBack: true }), "*")}
         >
           <FontAwesomeIcon icon={faHome} />
         </span>


### PR DESCRIPTION
## Summary
- Fix 6 activities failing to build on CI: MemoryMatch, MentalRotation, Nonogram, TowerOfLondon, WaterSort, and DelayDiscounting had CRA boilerplate index.html files referencing favicon.ico, logo192.png, and manifest.json that don't exist. The inline-source step in compress_activity.sh failed with ENOENT, producing empty (0-byte) dist files. Stripped to minimal HTML. 
- Fix back button and game result saving in all 10 new activities: Back/home buttons sent { abort: true } which the dashboard ignores — replaced with JSON.stringify({ clickBack: true }). Completion payloads were sent as raw objects instead of JSON strings — the dashboard does JSON.parse(e.data), so game results were silently lost.