### PR TITLE
fix: Add configurable delete button to DigitSpan digit entry

### DIFF
--- a/DigitSpan/src/components/Board.tsx
+++ b/DigitSpan/src/components/Board.tsx
@@ -44,6 +44,8 @@ export default function Board({ ...props }) {
   // ─── Config ──────────────────────────────────────────────────────────
   const [language, setLanguage] = useState("en-US");
   const [forward] = useState(props?.data?.forward ?? true);
+  const settings = props?.data?.activity?.settings ?? props?.data?.settings ?? {};
+  const allowDelete = settings.allow_delete !== undefined ? settings.allow_delete : true;
 
   // ─── Phase ───────────────────────────────────────────────────────────
   const [phase, setPhase] = useState<Phase>("instructions");
@@ -244,22 +246,61 @@ export default function Board({ ...props }) {
     });
     setLastClickTime(now);
 
-    // Auto-submit when all slots filled
+    // When all slots filled
     if (currentAnswers.length === currentSequence.length) {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
         timeoutRef.current = null;
       }
-      setTimeout(() => {
-        handleSequenceComplete(
-          currentAnswers,
-          currentSequence,
-          currentMode,
-          sequenceLengthRef.current
-        );
-      }, 300);
+      // If delete is disabled, auto-submit like before
+      if (!allowDelete) {
+        setTimeout(() => {
+          handleSequenceComplete(
+            currentAnswers,
+            currentSequence,
+            currentMode,
+            sequenceLengthRef.current
+          );
+        }, 300);
+      }
     }
-  }, [lastClickTime, handleSequenceComplete]);
+  }, [lastClickTime, handleSequenceComplete, allowDelete]);
+
+  // ─── Handle delete (remove last entered digit) ─────────────────────
+  const handleDelete = useCallback(() => {
+    if (!allowDelete || phase !== "answering") return;
+    const current = answersRef.current;
+    if (current.length === 0) return;
+
+    const updated = current.slice(0, -1);
+    setAnswers(updated);
+
+    // Record delete in routes
+    const now = new Date().getTime();
+    routesRef.current.push({
+      duration: now - lastClickTime,
+      item: "delete",
+      level: levelRef.current,
+      type: false,
+      value: null,
+      mode: modeRef.current,
+    });
+    setLastClickTime(now);
+  }, [allowDelete, phase, lastClickTime]);
+
+  // ─── Handle submit (user confirms answer) ──────────────────────────
+  const handleSubmit = useCallback(() => {
+    if (phase !== "answering") return;
+    const currentAnswers = answersRef.current;
+    const currentSequence = questionSequenceRef.current;
+    if (currentAnswers.length !== currentSequence.length) return;
+    handleSequenceComplete(
+      currentAnswers,
+      currentSequence,
+      modeRef.current,
+      sequenceLengthRef.current
+    );
+  }, [phase, handleSequenceComplete]);
 
   // ─── Send game result ───────────────────────────────────────────────
   const sendGameResult = useCallback((status?: boolean, isBack?: boolean, questionnaireData?: any) => {
@@ -434,6 +475,8 @@ export default function Board({ ...props }) {
             answers={answers}
             totalSlots={questionSequence.length}
             onTap={handleTap}
+            onDelete={allowDelete ? handleDelete : undefined}
+            onSubmit={allowDelete ? handleSubmit : undefined}
           />
         </div>
       )}

--- a/DigitSpan/src/components/DigitSpan.css
+++ b/DigitSpan/src/components/DigitSpan.css
@@ -128,9 +128,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
   gap: 8px;
-  margin: 16px 0 12px;
+  margin: 16px auto 12px;
   min-height: 48px;
+  max-width: 320px;
+  padding: 0 8px;
 }
 .answer-slot {
   display: inline-flex;
@@ -336,6 +339,66 @@
 .smileynav .btn svg {
   width: 100%;
   height: 100%;
+}
+
+/* ===== Delete Button (inline with answer slots) ===== */
+.delete-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 8px;
+  border: 2px solid #ccc;
+  background: #fafafa;
+  color: #999;
+  font-size: 1.4rem;
+  cursor: pointer;
+  user-select: none;
+  margin-left: 4px;
+  padding: 2px 1px 0 0;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.delete-btn:not(.disabled) {
+  border-color: #359FFE;
+  color: #359FFE;
+  background: #fff;
+}
+.delete-btn:hover:not(.disabled) {
+  background-color: #e8f0fe;
+  border-color: #0373d8;
+  color: #0373d8;
+}
+.delete-btn:active:not(.disabled) {
+  background-color: #d0e3fc;
+}
+.delete-btn.disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+/* ===== Submit Button ===== */
+.submit-btn-container {
+  display: flex;
+  justify-content: center;
+  margin: 16px 0;
+}
+.submit-btn {
+  background: #359FFE;
+  border: none;
+  border-radius: 40px;
+  color: #fff;
+  font-size: 1.6rem;
+  padding: 12px 48px;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s ease;
+}
+.submit-btn:hover {
+  background: #0373d8;
+}
+.submit-btn:active {
+  background: #025bb0;
 }
 
 /* ===== Responsive ===== */

--- a/DigitSpan/src/components/NumberGrid.tsx
+++ b/DigitSpan/src/components/NumberGrid.tsx
@@ -11,9 +11,11 @@ interface NumberGridProps {
   answers: number[];
   totalSlots: number;
   onTap: (num: number) => void;
+  onDelete?: () => void;
+  onSubmit?: () => void;
 }
 
-export default function NumberGrid({ disabled, answers, totalSlots, onTap }: NumberGridProps) {
+export default function NumberGrid({ disabled, answers, totalSlots, onTap, onDelete, onSubmit }: NumberGridProps) {
   const handleTap = useCallback((num: number) => {
     if (disabled) return;
     onTap(num);
@@ -27,7 +29,7 @@ export default function NumberGrid({ disabled, answers, totalSlots, onTap }: Num
 
   return (
     <div>
-      {/* Answer slots */}
+      {/* Answer slots + delete */}
       <div className="answer-slots">
         {slots.map((digit, i) => (
           <span
@@ -37,6 +39,15 @@ export default function NumberGrid({ disabled, answers, totalSlots, onTap }: Num
             {digit !== null ? digit : ""}
           </span>
         ))}
+        {onDelete && !disabled && (
+          <button
+            className={`delete-btn ${answers.length === 0 ? "disabled" : ""}`}
+            onClick={onDelete}
+            disabled={answers.length === 0}
+          >
+            &#x232B;
+          </button>
+        )}
       </div>
 
       {/* Keypad */}
@@ -46,12 +57,12 @@ export default function NumberGrid({ disabled, answers, totalSlots, onTap }: Num
             <div className="number-grid-row" key={rowIndex}>
               {row.map((num) => {
                 let cls = "number-grid-cell";
-                if (disabled) cls += " disabled";
+                if (disabled || answers.length >= totalSlots) cls += " disabled";
                 return (
                   <div
                     key={num}
                     className={cls}
-                    onClick={() => handleTap(num)}
+                    onClick={() => answers.length < totalSlots ? handleTap(num) : undefined}
                   >
                     {num}
                   </div>
@@ -61,6 +72,15 @@ export default function NumberGrid({ disabled, answers, totalSlots, onTap }: Num
           ))}
         </div>
       </div>
+
+      {/* Submit button — visible when all slots filled and delete is enabled */}
+      {onSubmit && answers.length === totalSlots && !disabled && (
+        <div className="submit-btn-container">
+          <button className="submit-btn" onClick={onSubmit}>
+            &#x2713;
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/DigitSpan/src/index.tsx
+++ b/DigitSpan/src/index.tsx
@@ -17,6 +17,8 @@ let root: ReturnType<typeof createRoot> | null = null;
 
 window.addEventListener(
   "message", (e: any) => {
+    // Ignore non-config messages (e.g., webpack HMR)
+    if (!e.data || typeof e.data !== "object" || !e.data.configuration) return;
     if (!root) {
       const rootElement = document.getElementById("root");
       if (rootElement) {

--- a/DigitSpan/test-harness.html
+++ b/DigitSpan/test-harness.html
@@ -152,6 +152,12 @@
           <option value="fr-FR">fr-FR</option>
         </select>
       </label>
+      <label>Delete:
+        <select id="allow-delete-select">
+          <option value="true" selected>Enabled</option>
+          <option value="false">Disabled</option>
+        </select>
+      </label>
       <button class="btn-send" onclick="sendConfig()">Send Config</button>
     </div>
   </div>
@@ -201,8 +207,10 @@
 
     function sendConfig() {
       var lang = document.getElementById('lang-select').value;
+      var allowDelete = document.getElementById('allow-delete-select').value === 'true';
       var config = Object.assign({
         configuration: { language: lang },
+        activity: { settings: { allow_delete: allowDelete } },
         noBack: false,
         forward: true,
       }, getConfig().extraConfig);


### PR DESCRIPTION
Adds allow_delete setting (defaults to true) that shows a backspace button inline with answer slots and a submit button after all slots are filled. When disabled, auto-submits on last digit like before. Filters non-config postMessages in index.tsx to prevent HMR from resetting settings. Answer slots now wrap on small screens.