### PR TITLE
Fix Jewels reporting a timeout when the participant completed the level

### DIFF
--- a/JewelsPro/src/components/jewels/Board.tsx
+++ b/JewelsPro/src/components/jewels/Board.tsx
@@ -149,7 +149,7 @@ class Board extends React.Component<BoardProps, DiamondState> {
           endTime: new Date(),
         },
         () => {
-          this.sendGameResult(1);
+          this.sendGameResult(1, false); // Timed out — stay on this level and end the game
         }
       );
     }
@@ -267,7 +267,10 @@ class Board extends React.Component<BoardProps, DiamondState> {
     return table;
   };
 
-  sendGameResult = (pointVal: number) => {
+  // pointVal is the `point` reported to the dashboard: 2 when the level was
+  // completed, 1 only when the clock ran out. advanceLevel is a separate
+  // decision — the user can complete a level and still choose to stop.
+  sendGameResult = (pointVal: number, advanceLevel: boolean) => {
     const totalBonusCollected =
       this.state.stepNumber === this.props.totalDiamonds
         ? this.state.startTimer - Math.abs(this.state.negativePoints)
@@ -279,15 +282,16 @@ class Board extends React.Component<BoardProps, DiamondState> {
       this.state.route,
       totalJewelsCollected,
       totalAttempts,
-      pointVal
+      pointVal,
+      advanceLevel
     );
   };
 
   handleConfirmClose = (status: boolean, pointVal: number) => {
     if (status === true) {
-      this.sendGameResult(2); // User accepted — advance to next level
+      this.sendGameResult(2, true); // User accepted — advance to next level
     } else {
-      this.sendGameResult(1); // User declined — end game at current level
+      this.sendGameResult(2, false); // User declined — level completed, but end here
     }
     this.setState({ showConfirmModal: false });
   };

--- a/JewelsPro/src/components/jewels/Jewels.tsx
+++ b/JewelsPro/src/components/jewels/Jewels.tsx
@@ -214,13 +214,14 @@ class Jewels extends React.Component<any, AppState> {
     routesValus: any,
     totalJewelsCollected: number,
     totalAttempts: number,
-    pointVal: number
+    pointVal: number,
+    advanceLevel: boolean
   ) => {
     this.updateRoutes(routesValus);
 
-    // Always advance on completion (pointVal=2), stay on timeout (pointVal=1)
-    const nextLevel =
-      pointVal === 2 ? this.state.level + 1 : this.state.level;
+    // Whether to move on is independent of pointVal: a user who completes a
+    // level and declines to continue reports point 2 but stays put.
+    const nextLevel = advanceLevel ? this.state.level + 1 : this.state.level;
 
     // If we've reached the max level, end the game
     if (nextLevel > this.state.totalLevels) {
@@ -233,7 +234,7 @@ class Jewels extends React.Component<any, AppState> {
             this.state.totalJewelsCollected + totalJewelsCollected,
         },
         () => {
-          this.handleClose(true, 1);
+          this.handleClose(true, pointVal);
         }
       );
       return;
@@ -283,7 +284,7 @@ class Jewels extends React.Component<any, AppState> {
       },
       () => {
         this.applyLevelColor(this.state.level);
-        pointVal === 1 ? this.handleClose(true, 1) : this.reset(true);
+        advanceLevel ? this.reset(true) : this.handleClose(true, pointVal);
       }
     );
   };


### PR DESCRIPTION
This PR proposes a fix for Jewels reporting a timeout when the participant completed the level. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/187. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`pointVal` in JewelsPro is doing two different jobs at once: deciding whether to advance a level, and telling the dashboard whether the game ended on a timeout. Those two meanings collided in commits `2526305` and `b206147`. `2526305` ("Fix JewelsPro showing 'Times Up' when user declines to continue") changed the `No` branch of `handleConfirmClose` to send `2`; two days later `b206147` ("Fix Jewels 'No' button still advancing to next level") had to change it back to `1`, because `1` was the only way to stay on the current level — which reinstated the false "Time's up!" the first commit removed. Neither value can be right while one number carries both meanings.

The consequence is not only cosmetic. `JewelsPro/DATA_DICTIONARY.md` defines `static_data.point` as "`2` if the final level was completed, `1` if the game ended on a timeout", but at `master` HEAD a participant who *completes* a level and answers `No` is recorded as `point: 1`. The same applies to finishing the game: the max-level branch of `updateLevel` calls `handleClose(true, 1)` with a hardcoded `1`, so every participant who plays through the last configured level is shown "Time's up!" and has their session stored as a timeout.

## Reproducing it on master

Using the workflow in your README, on `master` at `4f1b5ab`:

```
cd JewelsPro && npm install --legacy-peer-deps && npm start
```

Open `test-harness.html`, play a level to completion, and answer `No` to "Do you want to continue to next level?". The "Time's up!" overlay flashes and the payload in the harness's Raw JSON tab carries `"point": 1`. Configure `total_levels: 1` and answer `Yes` instead, and completing the whole game does the same thing.

## The fix

`sendGameResult` and `updateLevel` now take an explicit `advanceLevel` flag alongside `pointVal`, so level progression and the timeout signal stop competing for one number. `pointVal` then means exactly what the data dictionary says it means, and the hardcoded `1` in the max-level branch becomes the real `pointVal`. Declining keeps `b206147`'s behaviour of staying on the current level while reporting `point: 2`; this is the outcome `2526305` was reaching for, now reachable without giving up the later fix.

Nothing outside the two components changed — no settings, no payload fields added or removed, and `temporal_slices`, `score`, `total_bonus_collected` and the questionnaire path are untouched. Existing sessions that genuinely time out serialize exactly as before.

## Verification

The repo has no automated test harness, so I drove the production `npm run build` of the activity in headless Chrome and scripted all four ways a level can end, including the two that must not change. Against unmodified `master` the four checks below marked `FAIL` fail; with this patch all nine pass.

```
--- master 4f1b5ab ---            --- with this patch ---
FAIL decline: no overlay          PASS decline: no overlay
FAIL decline: reports point 2     PASS decline: reports point 2
PASS decline: does NOT advance    PASS decline: does NOT advance
PASS accept: no overlay           PASS accept: no overlay
PASS accept: advances to level 2  PASS accept: advances to level 2
FAIL final level: no overlay      PASS final level: no overlay
FAIL final level: reports point 2 PASS final level: reports point 2
PASS timeout: overlay still shown PASS timeout: overlay still shown
PASS timeout: reports point 1     PASS timeout: reports point 1
5/9 passed                        9/9 passed
```

The two control rows are the point of the exercise: `accept: advances to level 2` is the regression `b206147` fixed, and `timeout: overlay still shown` / `timeout: reports point 1` confirm a genuine timeout is untouched. `npx tsc --noEmit` and `CI=1 npm run build` are clean before and after, with the bundle 4 bytes larger.

## How this was managed

This work was tracked as a single story on a board imported from this repository's own 561 issues and pull requests: [the story for this fix](https://eastagiletracker.com/projects/187/stories/55691), on [the board](https://eastagiletracker.com/projects/187).

![board](https://raw.githubusercontent.com/eastagiletracker/LAMP-activities/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
